### PR TITLE
Drop blueprint-compiler

### DIFF
--- a/io.github.getnf.embellish.yml
+++ b/io.github.getnf.embellish.yml
@@ -31,15 +31,6 @@ modules:
             url: https://download.gnome.org/sources/gnome-autoar/0.4/gnome-autoar-0.4.5.tar.xz
             sha256: 838c5306fc38bfaa2f23abe24262f4bf15771e3303fb5dcb74f5b9c7a615dabe
 
-    - name: blueprint-compiler
-      buildsystem: meson
-      cleanup:
-        - '*'
-      sources:
-        - type: git
-          url: https://gitlab.gnome.org/jwestman/blueprint-compiler
-          tag: v0.16.0
-
     - name: embellish
       buildsystem: meson
       sources:


### PR DESCRIPTION
GNOME runtime version 49 already provides this module.